### PR TITLE
gitignore vsscode and kotlin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
 .idea
 .gradle
+.vscode
+.kotlin
 /gradle.properties


### PR DESCRIPTION
Thie pull request puts two directories to the `.gitignore` list:

* `.vscode` which is used as setting directory for Visual Studio Code similar to Intellij's `.idea`
* `.kotlin` which is used for debugging sessions of the Kotlin compiler